### PR TITLE
hack: disable 'Invalid credentials' prompt (fixes #4)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,8 @@
           patchPhase = ''
             runHook prePatch
 
+            patch -p1 -d kvmd-src < ${./patches/kvmd/disable-login-fail-window.patch}
+
             # HACK: patch ctypes.util.find_library calls because nixpkgs#7307 is somehow not fixed yet
             sed -i 's|ctypes.util.find_library("tesseract")|"${pkgs.tesseract}/lib/libtesseract.so.5"|' kvmd-src/kvmd/apps/kvmd/ocr.py
             sed -i 's|ctypes.util.find_library("xkbcommon")|"${pkgs.libxkbcommon}/lib/libxkbcommon.so.0"|' kvmd-src/kvmd/keyboard/printer.py

--- a/patches/kvmd/disable-login-fail-window.patch
+++ b/patches/kvmd/disable-login-fail-window.patch
@@ -1,0 +1,28 @@
+diff --git a/web/login/index.html b/web/login/index.html
+index 26b07640..93595f17 100644
+--- a/web/login/index.html
++++ b/web/login/index.html
+@@ -71,6 +71,9 @@
+                 <hr>
+               </td>
+             </tr>
++            <tr>
++              <td id="err-msg" colspan="2"></td>
++            </tr>
+             <tr>
+               <td></td>
+               <td>
+diff --git a/web/share/js/login/main.js b/web/share/js/login/main.js
+index 41ed6141..a38a8f14 100644
+--- a/web/share/js/login/main.js
++++ b/web/share/js/login/main.js
+@@ -55,7 +55,8 @@ function __login() {
+ 			if (http.status === 200) {
+ 				document.location.href = "/";
+ 			} else if (http.status === 403) {
+-				wm.error("Invalid credentials").then(__tryAgain);
++				$("err-msg").setHTML("Error: Invalid credentials")
++				__tryAgain()
+ 			} else {
+ 				let error = "";
+ 				if (http.status === 400) {


### PR DESCRIPTION
Replaces the window with a message in the login form